### PR TITLE
Fix critical bug in StateVar

### DIFF
--- a/Runtime/StateVar/StateVar.cs
+++ b/Runtime/StateVar/StateVar.cs
@@ -30,7 +30,7 @@ namespace AbandonedCrypt.EditorState
       get => _value;
       set
       {
-        if (_value.Equals(value)) return;
+        if (_value != null && _value.Equals(value)) return;
         _value = value;
         ReRenderHost();
       }


### PR DESCRIPTION
StateVar had a critical but where when assigned null, further value retrievals would trigger a null pointer exception due to the comparison condition expecting _value to be initialized.